### PR TITLE
add italian translation

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,20 @@
+<resources>
+    <string name="app_name" translatable="false">SherpaTTS</string>
+    <string name="start_main">AVVIA</string>
+    <string name="error_download">Errore durante lo scaricamento</string>
+    <string name="dialog_StarOnGitHub">Ti piace questa app? Perfavore dai una stella su GitHub o offri un caffè allo sviluppatore tramite PayPal.</string>
+    <string name="dialog_Later_button">Forse dopo</string>
+    <string name="play">Play</string>
+    <string name="stop">Stop</string>
+    <string name="speed">Velocità</string>
+    <string name="speaker_id">Speaker ID:</string>
+    <string name="language_id">Lingua\u2009</string>
+    <string name="input">Inserisci del testo per generare</string>
+    <string name="download_language">Scarica lingua</string>
+    <string name="test_languages">Prova i modelli</string>
+    <string name="add_language">Aggiungi lingua</string>
+    <string name="delete_language">Elimina lingua</string>
+    <string name="piper_models">Modelli Piper</string>
+    <string name="coqui_models">Modelli Coqui</string>
+    <string name="apply_system_speed">Applicare le impostazioni di sistema (velocità/tono) per l'utilizzo come motore TTS a livello di sistema</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name" translatable="false">SherpaTTS</string>
     <string name="start_main">AVVIA</string>
     <string name="error_download">Errore durante lo scaricamento</string>
     <string name="dialog_StarOnGitHub">Ti piace questa app? Perfavore dai una stella su GitHub o offri un caffè allo sviluppatore tramite PayPal.</string>
@@ -16,5 +15,5 @@
     <string name="delete_language">Elimina lingua</string>
     <string name="piper_models">Modelli Piper</string>
     <string name="coqui_models">Modelli Coqui</string>
-    <string name="apply_system_speed">Applicare le impostazioni di sistema (velocità/tono) per l'utilizzo come motore TTS a livello di sistema</string>
+    <string name="apply_system_speed">Applicare le impostazioni di sistema (velocità/tono) per l\'utilizzo come motore TTS a livello di sistema</string>
 </resources>

--- a/fastlane/metadata/android/it-IT/full_description.txt
+++ b/fastlane/metadata/android/it-IT/full_description.txt
@@ -1,0 +1,4 @@
+SherpaTTS è un motore Text-to-Speech Android basato su Kaldi di nuova generazione che utilizza le voci Piper o Coqui.
+Al primo avvio dell'app, verrà scaricato il modello vocale preferito da Hugging Face.
+Si prega di notare che questa è l'unico momento in cui è richiesta l'autorizzazione Internet.
+Una volta scaricato il modello, il text-to-speech funziona completamente offline, garantendo la privacy e la comodità.

--- a/fastlane/metadata/android/it-IT/short_description.txt
+++ b/fastlane/metadata/android/it-IT/short_description.txt
@@ -1,0 +1,1 @@
+Motore di sintesi vocale basato su Kaldi di nuova generazione

--- a/fastlane/metadata/android/it-IT/title.txt
+++ b/fastlane/metadata/android/it-IT/title.txt
@@ -1,0 +1,1 @@
+SherpaTTS


### PR DESCRIPTION
I have added italian translation of both app and faslane for F-Droid.

IMHO the string "apply_system_speed" is too long, both on englsh and in italian, I have still translate all the entity string, but "Apply system settings (speed / pitch)" maybe should suffice.